### PR TITLE
Fixed package not working on android

### DIFF
--- a/android/src/main/kotlin/wtf/flutter/vr_player/VideoPlayerController.kt
+++ b/android/src/main/kotlin/wtf/flutter/vr_player/VideoPlayerController.kt
@@ -284,6 +284,7 @@ class VideoPlayerController(
                 PlayerState.BUFFERING -> {
                     playerEventStateChanged?.success(mapOf(Pair("state", 2)))
                 }
+                else -> {}
             }
         }
 


### PR DESCRIPTION
Fixed Issue with android 
vr_player-0.1.1/android/src/main/kotlin/wtf/flutter/vr_player/VideoPlayerController.kt: (270, 13): 'when' expression must be exhaustive, add necessary 'IDLE' branch or 'else' branch instead

FAILURE: Build failed with an exception.

What went wrong:
Execution failed for task ':vr_player:compileDebugKotlin'.
A failure occurred while executing org.jetbrains.kotlin.compilerRunner.GradleCompilerRunnerWithWorkers$GradleKotlinCompilerWorkAction
Compilation error. See log for more details